### PR TITLE
Hide main img tag when noscript

### DIFF
--- a/js/lazy-load.js
+++ b/js/lazy-load.js
@@ -3,7 +3,7 @@
 	$( 'body' ).bind( 'post-load', lazy_load_init ); // Work with WP.com infinite scroll
 
 	function lazy_load_init() {
-		$( 'img' ).lazyload( {
+		$( 'img' ).show().lazyload( {
 			threshold: 200,
 			effect: 'fadeIn',
 			data_attribute: 'lazy-src'

--- a/lazy-load.php
+++ b/lazy-load.php
@@ -45,7 +45,7 @@ class LazyLoad_Images {
 	// This is a pretty simple regex, but it works
 	// Remember to put data-lazy-src as the data attribute if you want to
 	// serve your images through photon. They work locally too, though
-	$val = preg_replace( '#<img([^>]+?)src=[\'"]?([^\'"\s>]+)[\'"]?([^>]*)>#', sprintf( '<img${1}data-lazy-src="${2}"${3}><noscript><img${1}src="${2}"${3}></noscript>', $placeholder_image ), $val );
+	$val = preg_replace( '#<img([^>]+?)src=[\'"]?([^\'">]+)[\'"]?([^>]*)([^>]+?)style=[\'"]?([^\'">]+)[\'"]?([^>]*)>#', sprintf( '<img${1}data-lazy-src="${2}"${3}${4}style="display: none; ${5}"${6}><noscript><img${1}src="${2}"${3}${4}style="${5}"${6}></noscript>', $placeholder_image ), $val );
 
 	return $val;
 	}

--- a/lazy-load.php
+++ b/lazy-load.php
@@ -45,7 +45,7 @@ class LazyLoad_Images {
 	// This is a pretty simple regex, but it works
 	// Remember to put data-lazy-src as the data attribute if you want to
 	// serve your images through photon. They work locally too, though
-	$val = preg_replace( '#<img([^>]+?)src=[\'"]?([^\'">]+)[\'"]?([^>]*)([^>]+?)style=[\'"]?([^\'">]+)[\'"]?([^>]*)>#', sprintf( '<img${1}data-lazy-src="${2}"${3}${4}style="display: none; ${5}"${6}><noscript><img${1}src="${2}"${3}${4}style="${5}"${6}></noscript>', $placeholder_image ), $val );
+	$val = preg_replace( '#<img([^>]+?)src=[\'"]?([^\'"\s>]+)[\'"]?([^>]*)([^>]+?)style=[\'"]?([^\'">]+)[\'"]?([^>]*)>#', sprintf( '<img${1}data-lazy-src="${2}"${3}${4}style="display: none; ${5}"${6}><noscript><img${1}src="${2}"${3}${4}style="${5}"${6}></noscript>', $placeholder_image ), $val );
 
 	return $val;
 	}


### PR DESCRIPTION
Not so clean, but according to manual it's needed to hide main <img> by default, otherwise when no JS enabled, main <img> will be covered that from <noscript>
